### PR TITLE
add Timeout field to REST client (1.4, 1.5) config

### DIFF
--- a/1.4/rest/config.go
+++ b/1.4/rest/config.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/golang/glog"
 
+    "time"
+
 	"k8s.io/client-go/1.4/pkg/api"
 	"k8s.io/client-go/1.4/pkg/api/unversioned"
 	"k8s.io/client-go/1.4/pkg/runtime"
@@ -108,6 +110,9 @@ type Config struct {
 
 	// Rate limiter for limiting connections to the master from this client. If present overwrites QPS/Burst
 	RateLimiter flowcontrol.RateLimiter
+
+	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
+    Timeout time.Duration
 
 	// Version forces a specific version to be used (if registered)
 	// Do we need this?

--- a/1.5/rest/config.go
+++ b/1.5/rest/config.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/golang/glog"
 
+    "time"
+
 	"k8s.io/client-go/1.5/pkg/api"
 	"k8s.io/client-go/1.5/pkg/api/unversioned"
 	"k8s.io/client-go/1.5/pkg/runtime"
@@ -108,6 +110,9 @@ type Config struct {
 
 	// Rate limiter for limiting connections to the master from this client. If present overwrites QPS/Burst
 	RateLimiter flowcontrol.RateLimiter
+
+    // The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
+    Timeout time.Duration
 
 	// Version forces a specific version to be used (if registered)
 	// Do we need this?


### PR DESCRIPTION
Fixes test panics in k8s PR:
https://github.com/kubernetes/kubernetes/pull/33958
and OpenShift PR: https://github.com/openshift/origin/pull/11104

The linked Kubernetes PR adds a "Timeout" field to the rest client in
order to implement global http request timeouts for server requests.

@soltysh @fabianofranz 