### PR TITLE
Make example codes buildable with the latest client-go

### DIFF
--- a/examples/in-cluster/main.go
+++ b/examples/in-cluster/main.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/client-go/1.4/kubernetes"
-	"k8s.io/client-go/1.4/pkg/api"
-	"k8s.io/client-go/1.4/rest"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
 )
 
 func main() {
@@ -37,7 +37,7 @@ func main() {
 		panic(err.Error())
 	}
 	for {
-		pods, err := clientset.Core().Pods("").List(api.ListOptions{})
+		pods, err := clientset.Core().Pods("").List(v1.ListOptions{})
 		if err != nil {
 			panic(err.Error())
 		}

--- a/examples/out-of-cluster/main.go
+++ b/examples/out-of-cluster/main.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/client-go/1.4/kubernetes"
-	"k8s.io/client-go/1.4/pkg/api"
-	"k8s.io/client-go/1.4/tools/clientcmd"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
@@ -43,7 +43,7 @@ func main() {
 		panic(err.Error())
 	}
 	for {
-		pods, err := clientset.Core().Pods("").List(api.ListOptions{})
+		pods, err := clientset.Core().Pods("").List(v1.ListOptions{})
 		if err != nil {
 			panic(err.Error())
 		}

--- a/examples/third-party-resources/main.go
+++ b/examples/third-party-resources/main.go
@@ -4,19 +4,19 @@ import (
 	"flag"
 	"fmt"
 
-	"k8s.io/client-go/1.5/kubernetes"
-	"k8s.io/client-go/1.5/pkg/api"
-	"k8s.io/client-go/1.5/pkg/api/errors"
-	"k8s.io/client-go/1.5/pkg/api/unversioned"
-	"k8s.io/client-go/1.5/pkg/api/v1"
-	"k8s.io/client-go/1.5/pkg/apis/extensions/v1beta1"
-	"k8s.io/client-go/1.5/pkg/runtime"
-	"k8s.io/client-go/1.5/pkg/runtime/serializer"
-	"k8s.io/client-go/1.5/rest"
-	"k8s.io/client-go/1.5/tools/clientcmd"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/pkg/runtime"
+	"k8s.io/client-go/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	// Only required to authenticate against GKE clusters
-	_ "k8s.io/client-go/1.5/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 var (

--- a/examples/third-party-resources/types.go
+++ b/examples/third-party-resources/types.go
@@ -3,9 +3,9 @@ package main
 import (
 	"encoding/json"
 
-	"k8s.io/client-go/1.5/pkg/api"
-	"k8s.io/client-go/1.5/pkg/api/meta"
-	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/meta"
+	"k8s.io/client-go/pkg/api/unversioned"
 )
 
 type ExampleSpec struct {


### PR DESCRIPTION
## WHY

Currently, examples cannot be built with master / v2.0.0-alpha version of client-go.

```
$ go build -v
main.go:24:2: cannot find package "k8s.io/client-go/1.4/kubernetes" in any of:
        /Users/dtan4/src/github.com/kubernetes/client-go/vendor/k8s.io/client-go/1.4/kubernetes (vendor tree)
        /usr/local/Cellar/go/1.7.3/libexec/src/k8s.io/client-go/1.4/kubernetes (from $GOROOT)
        /Users/dtan4/src/k8s.io/client-go/1.4/kubernetes (from $GOPATH)
main.go:25:2: cannot find package "k8s.io/client-go/1.4/pkg/api" in any of:
        /Users/dtan4/src/github.com/kubernetes/client-go/vendor/k8s.io/client-go/1.4/pkg/api (vendor tree)
        /usr/local/Cellar/go/1.7.3/libexec/src/k8s.io/client-go/1.4/pkg/api (from $GOROOT)
        /Users/dtan4/src/k8s.io/client-go/1.4/pkg/api (from $GOPATH)
main.go:26:2: cannot find package "k8s.io/client-go/1.4/tools/clientcmd" in any of:
        /Users/dtan4/src/github.com/kubernetes/client-go/vendor/k8s.io/client-go/1.4/tools/clientcmd (vendor tree)
        /usr/local/Cellar/go/1.7.3/libexec/src/k8s.io/client-go/1.4/tools/clientcmd (from $GOROOT)
        /Users/dtan4/src/k8s.io/client-go/1.4/tools/clientcmd (from $GOPATH)
```

## WHAT

Make example codes buildable with master version.

I read https://github.com/kubernetes/client-go#contributing-code and found `pkg/client` package. However, it seemed that `examples` directory did not exist there, so I made this pull request directly in this repository.

If there is another proper way to send patches, please let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/client-go/39)
<!-- Reviewable:end -->
