### PR TITLE
Cleanup example

### DIFF
--- a/examples/out-of-cluster/main.go
+++ b/examples/out-of-cluster/main.go
@@ -26,11 +26,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var (
-	kubeconfig = flag.String("kubeconfig", "./config", "absolute path to the kubeconfig file")
-)
-
 func main() {
+	kubeconfig := flag.String("kubeconfig", "./config", "absolute path to the kubeconfig file")
 	flag.Parse()
 	// uses the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)

--- a/examples/third-party-resources/main.go
+++ b/examples/third-party-resources/main.go
@@ -35,10 +35,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
-var (
-	config *rest.Config
-)
-
 func main() {
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kube config. Only required if out-of-cluster.")
 	flag.Parse()

--- a/examples/third-party-resources/types_test.go
+++ b/examples/third-party-resources/types_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ runtime.Object = &Example{}
+var _ metav1.ObjectMetaAccessor = &Example{}
+
+var _ runtime.Object = &ExampleList{}
+var _ metav1.ListMetaAccessor = &ExampleList{}


### PR DESCRIPTION
Fix for #59. I'm not sure about `Schema` - see [the comment in the `init()` function](https://github.com/kubernetes/kubernetes/blob/master/pkg/api/register.go#L75). If a new Schema is created for the client does it need to have those converter functions added manually?