### PR TITLE
Fix build of third-party-resource example program

### DIFF
--- a/examples/third-party-resources/main.go
+++ b/examples/third-party-resources/main.go
@@ -4,15 +4,14 @@ import (
 	"flag"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
-	"k8s.io/client-go/pkg/api/errors"
-	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
-	"k8s.io/client-go/pkg/runtime"
-	"k8s.io/client-go/pkg/runtime/schema"
-	"k8s.io/client-go/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -44,7 +43,7 @@ func main() {
 	if err != nil {
 		if errors.IsNotFound(err) {
 			tpr := &v1beta1.ThirdPartyResource{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "example.k8s.io",
 				},
 				Versions: []v1beta1.APIVersion{
@@ -87,7 +86,7 @@ func main() {
 		if errors.IsNotFound(err) {
 			// Create an instance of our TPR
 			example := &Example{
-				Metadata: api.ObjectMeta{
+				Metadata: metav1.ObjectMeta{
 					Name: "example1",
 				},
 				Spec: ExampleSpec{

--- a/examples/third-party-resources/types.go
+++ b/examples/third-party-resources/types.go
@@ -3,10 +3,8 @@ package main
 import (
 	"encoding/json"
 
-	"k8s.io/client-go/pkg/api"
-	"k8s.io/client-go/pkg/api/meta"
-	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
-	"k8s.io/client-go/pkg/runtime/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type ExampleSpec struct {
@@ -16,7 +14,7 @@ type ExampleSpec struct {
 
 type Example struct {
 	metav1.TypeMeta `json:",inline"`
-	Metadata        api.ObjectMeta `json:"metadata"`
+	Metadata        metav1.ObjectMeta `json:"metadata"`
 
 	Spec ExampleSpec `json:"spec"`
 }
@@ -34,7 +32,7 @@ func (e *Example) GetObjectKind() schema.ObjectKind {
 }
 
 // Required to satisfy ObjectMetaAccessor interface
-func (e *Example) GetObjectMeta() meta.Object {
+func (e *Example) GetObjectMeta() metav1.Object {
 	return &e.Metadata
 }
 


### PR DESCRIPTION
The TPR example was broken by the extraction of much
client-go code into the apimachinery package.

