### PR TITLE
Fix broken example

### DIFF
--- a/examples/in-cluster/main.go
+++ b/examples/in-cluster/main.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )


### PR DESCRIPTION
Installing and trying to run this example gives an error. This update fixes the issue.
