### PR TITLE
Fix readme

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,11 +126,11 @@ own project (change the `project: ` line at the top!), or, if you already have a
 `glide.yaml` file, you'll need to merge this `glide.yaml` with it.
 
 At this point, your `glide.yaml` file has all the dependencies of the client
-library, but doesn't list the client itself. Running `glide install
+library, but doesn't list the client itself. Running `glide get
 --strip-vendor k8s.io/client-go#^2.0.0` will add `client-go` to the dependency
 list, and all the dependencies should resolve correctly.
 
-Note that simply running `glide install k8s.io/client-go#^2.0.0` without first
+Note that simply running `glide get k8s.io/client-go#^2.0.0` without first
 getting the dependencies sorted out doesn't seem to trigger glide's
 import-from-godep code, and as a consequence it doesn't resolve the dependencies
 correctly.


### PR DESCRIPTION
`glide install` will not add a dependency to the `glide.yaml` file.

```
glide install --help
NAME:
   glide install - Install a project's dependencies

USAGE:
   glide install [command options] [arguments...]

DESCRIPTION:
   This uses the native VCS of each package to install
   the appropriate version. There are two ways a project's dependencies can
   be installed. When there is a glide.yaml file defining the dependencies but
   no lock file (glide.lock) the dependencies are installed using the "update"
   command and a glide.lock file is generated pinning all dependencies. If a
   glide.lock file is already present the dependencies are installed or updated
   from the lock file.

OPTIONS:
   --force             If there was a change in the repo or VCS switch to new one. Warning: changes will be lost.
   --strip-vendor, -v  Removes nested vendor and Godeps/_workspace directories.
   --skip-test         Resolve dependencies in test files.
```
```
glide get --help
NAME:
   glide get - Install one or more packages into `vendor/` and add dependency to glide.yaml.

USAGE:
   glide get [command options] [arguments...]

DESCRIPTION:
   Gets one or more package (like 'go get') and then adds that file
   to the glide.yaml file. Multiple package names can be specified on one line.

       $ glide get github.com/Masterminds/cookoo/web

   The above will install the project github.com/Masterminds/cookoo and add
   the subpackage 'web'.

   If a fetched dependency has a glide.yaml file, configuration from Godep,
   GPM, GOM, or GB Glide that configuration will be used to find the dependencies
   and versions to fetch. If those are not available the dependent packages will
   be fetched as either a version specified elsewhere or the latest version.

   When adding a new dependency Glide will perform an update to work out the
   the versions for the dependencies of this dependency (transitive ones). This
   will generate an updated glide.lock file with specific locked versions to use.

   The '--strip-vendor' flag will remove any nested 'vendor' folders and
   'Godeps/_workspace' folders after an update (along with undoing any Godep
   import rewriting). Note, The Godeps specific functionality is deprecated and
   will be removed when most Godeps users have migrated to using the vendor
   folder.

OPTIONS:
   --test                   Add test dependencies.
   --insecure               Use http:// rather than https:// to retrieve packages.
   --no-recursive, --quick  Disable updating dependencies' dependencies.
   --force                  If there was a change in the repo or VCS switch to new one. Warning, changes will be lost.
   --all-dependencies       This will resolve all dependencies for all packages, not just those directly used.
   --resolve-current        Resolve dependencies for only the current system rather than all build modes.
   --strip-vendor, -v       Removes nested vendor and Godeps/_workspace directories.
   --non-interactive        Disable interactive prompts.
   --skip-test              Resolve dependencies in test files.
```