### PR TITLE
Update dep usage in install docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,11 +36,30 @@ the box.
 ```sh
 $ go get github.com/golang/dep
 $ go install github.com/golang/dep/cmd/dep
+```
 
-# Make sure you have a go file in your directory which imports k8s.io/client-go
-# first--I suggest copying one of the examples.
-$ dep init
-$ dep ensure k8s.io/client-go@^2.0.0
+First, make sure you have a go file in your directory which imports k8s.io/client-go -- I suggest copying one of the examples (from the same release version of client-go).
+
+Next, create a `manifest.json` file at the root of your project:
+
+```json
+{
+    "dependencies": {
+        "k8s.io/client-go": {
+            "version": "v2.0.0"
+        },
+        "github.com/emicklei/go-restful": {
+            "version": "v1.2"
+        }
+    }
+}
+
+```
+
+And finally, run:
+
+```sh
+$ dep ensure
 ```
 
 This will set up a `vendor` directory in your current directory, add `k8s.io/client-go`


### PR DESCRIPTION
Apologies if this really shouldn't be opened here.

Gave `dep` a shot for the first time, and due to some recently added tags to the `go-restful` package, the instructions weren't working (latest tag 2.2.0 doesn't contain go-restful/swagger package, which is required by client-go).

There might be a better way to handle this rather than pre-populating the `manifest.json`, but a couple quick cli tests didn't work (e.g. running `ensure go-restful@v1.2`).

Related: https://github.com/kubernetes/client-go/issues/107 (but also not sure prefered way to implement auto tests...)
