### PR TITLE
Update Links for How to Use It

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ management system. See [INSTALL.md](/INSTALL.md) for detailed instructions.
 
 ### How to use it
 
-If your application runs in a Pod in the cluster, please refer to the in-cluster [example](examples/in-cluster/main.go), otherwise please refer to the out-of-cluster [example](examples/out-of-cluster/main.go).
+If your application runs in a Pod in the cluster, please refer to the in-cluster [example](examples/in-cluster-client-configuration), otherwise please refer to the out-of-cluster [example](examples/out-of-cluster-client-configuration).
 
 ### Dependency management
 


### PR DESCRIPTION
Updates the Links for the "How to Use It" Section of the Readme.
Currently the links are sending the user to a 404 Package due to
changes of the documentation path. Also now we show docs rather
than the main.go.
