### PR TITLE
Fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ management system. See [INSTALL.md](/INSTALL.md) for detailed instructions.
 
 ### How to use it
 
-If your application runs in a Pod in the cluster, please refer to the in-cluster [example](examples/in-cluster/main.go), otherwise please refer to the out-of-cluster [example](examples/out-of-cluster/main.go).
+If your application runs in a Pod in the cluster, please refer to the in-cluster [example](examples/in-cluster-client-configuration/main.go), otherwise please refer to the out-of-cluster [example](examples/out-of-cluster-client-configuration/main.go).
 
 ### Dependency management
 


### PR DESCRIPTION
Adding this as a PR because the staging/src/ in `kubernetes/kubernetes` doesn't seem to have the README itself.

Patch fixes links to in-cluster/out-of-cluster exmaples point to
non-existent paths.
