### PR TITLE
README.md: fix broken links to examples in & out of cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ will give you head and doesn't handle the dependencies well.
 [![GoDoc](https://godoc.org/k8s.io/client-go?status.svg)](https://godoc.org/k8s.io/client-go)
 
 ## Table of Contents
- 
+
 - [What's included](#whats-included)
 - [Versioning](#versioning)
   - [Compatibility: your code <-> client-go](#compatibility-your-code---client-go)
@@ -142,7 +142,9 @@ management system. See [INSTALL.md](/INSTALL.md) for detailed instructions.
 
 ### How to use it
 
-If your application runs in a Pod in the cluster, please refer to the in-cluster [example](examples/in-cluster/main.go), otherwise please refer to the out-of-cluster [example](examples/out-of-cluster/main.go).
+If your application runs in a Pod in the cluster, please refer to the
+in-cluster [example](examples/in-cluster-client-configuration), otherwise please
+refer to the out-of-cluster [example](examples/out-of-cluster-client-configuration).
 
 ### Dependency management
 


### PR DESCRIPTION
Seems like this file isn't in the main Kubernetes repo, so here's a PR to fix its broken link.