### PR TITLE
Fix: 'kubernetes' should be start with 'K'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ https://github.com/kubernetes/client-go/issues/234.
 ** Breaking changes**
 
 pkg/api and pkg/apis are moved to
-[k8s.io/api](https://github.com/kubernetes/api). Other kubernetes repositories
+[k8s.io/api](https://github.com/kubernetes/api). Other Kubernetes repositories
 also import types from there, so they are composable with client-go.
 
 Helper functions in pkg/api and pkg/apis are also removed. They are planned to


### PR DESCRIPTION
Sorry, client-go does not accept changes via pull requests at this time. Please
submit your pull request to the main repository:
https://github.com/kubernetes/kubernetes.  See the guidance here:
https://github.com/kubernetes/client-go#contributing-code.
