### PR TITLE
Rewording for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Go clients for talking to a [kubernetes](http://kubernetes.io/) cluster.
 
 We currently recommend using the v7.0.0 tag. See [INSTALL.md](/INSTALL.md) for
 detailed installation instructions. `go get k8s.io/client-go/...` works, but
-will give you head and doesn't handle the dependencies well.
+will build `master`, which doesn't handle the dependencies well.
 
 [![BuildStatus Widget]][BuildStatus Result]
 [![GoReport Widget]][GoReport Status]


### PR DESCRIPTION
Signed-off-by: Misty Stanley-Jones <mistyhacks@google.com>

Fixes #419 

Yes I read the notice below, but the `README.md` is not in `kubernetes/kubernetes` (or I certainly can't find it), so I think this is the only way to fix this.

```
Sorry, we do not accept changes directly against this repository. Please see 
CONTRIBUTING.md for information on where and how to contribute instead.
```
