### PR TITLE
Revert non-staging change to .github/PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,2 @@
-Sorry, we do not accept changes directly against this repository, unless the
-change is to the `README.md` itself. Please see 
-`CONTRIBUTING.md` for information on where and how to contribute instead.
+Sorry, we do not accept changes directly against this repository. Please see 
+CONTRIBUTING.md for information on where and how to contribute instead.


### PR DESCRIPTION
Stop the bot falling over, reverting part of https://github.com/kubernetes/client-go/pull/421.

Compare: the original file is at https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/client-go/.github