### PR TITLE
Bump go version to 1.10.2 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: go
 go_import_path: k8s.io/client-go
 
 go:
-  - 1.8.1
+  - 1.10.2
 
 script: go build ./...


### PR DESCRIPTION
The travis build fails with `undefined: strings.Builder`. This is due to an old go version (1.8.1 :scream: )

Also, see a similar fix for publishing bot for more details: https://github.com/kubernetes/publishing-bot/pull/74.

This blocks merging any PRs sent directly to this repo: https://github.com/kubernetes/client-go/pull/466.

/assign @sttts 