### PR TITLE
Bump go version to 1.10.2 for travis for release-9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: go
 go_import_path: k8s.io/client-go
 
 go:
-  - 1.8.1
+  - 1.10.2
 
 script: go build ./...


### PR DESCRIPTION
Travis is broken on release-9.0. This PR fixes it and unblocks other direct PRs to this repo on release-9.0.

See https://github.com/kubernetes/client-go/pull/467 - similar PR for master for more details.