### PR TITLE
travis: run godep restore for non-master branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ go_import_path: k8s.io/client-go
 go:
   - 1.10.2
 
-script: go build ./...
+script:
+  - if [ "$TRAVIS_BRANCH" != "master" ]; then godep restore; fi
+  - go build ./...


### PR DESCRIPTION
Currently, we just run `go build ./...` in travis. This means that go build ends up using master branches of client-go's dependencies (apimachinery, api) for building the non-master branches. This will fail almost all the time for non-master branches.

So, for non-master branches we should run `godep restore && go build ./...`.