### PR TITLE
travis: bump go version to 1.11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: go
 go_import_path: k8s.io/client-go
 
 go:
-  - 1.11.1
+  - 1.11.2
 
 script:
-  - if [ "$TRAVIS_BRANCH" != "master" ]; then godep restore; fi
   - go build ./...


### PR DESCRIPTION
Ref for bumping go version: https://github.com/kubernetes/kubernetes/pull/70665

`godep restore` is automatically run by Travis CI, so we don't really need an explicit godep step for it.

/assign @sttts 