### PR TITLE
Update command to start the deployment

### DIFF
--- a/examples/in-cluster-client-configuration/README.md
+++ b/examples/in-cluster-client-configuration/README.md
@@ -37,7 +37,7 @@ kubectl create clusterrolebinding default-view --clusterrole=view --serviceaccou
 
 Then, run the image in a Pod with a single instance Deployment:
 
-    kubectl run --rm -i demo --image=in-cluster --image-pull-policy=Never
+    kubectl run --rm -i demo --image=in-cluster
 
     There are 4 pods in the cluster
     There are 4 pods in the cluster


### PR DESCRIPTION
Removed the --image-pull-policy=Never option
it causes the pod to be in state: ErrImageNeverPull

Sorry, we do not accept changes directly against this repository, unless the
change is to the `README.md` itself. Please see
`CONTRIBUTING.md` for information on where and how to contribute instead.
