### PR TITLE
Fix Failed to release lock

### DIFF
--- a/tools/leaderelection/leaderelection.go
+++ b/tools/leaderelection/leaderelection.go
@@ -300,6 +300,7 @@ func (le *LeaderElector) release() bool {
 		return true
 	}
 	leaderElectionRecord := rl.LeaderElectionRecord{
+		LeaseDurationSeconds: int(le.config.LeaseDuration.Seconds()),
 		LeaderTransitions: le.observedRecord.LeaderTransitions,
 	}
 	if err := le.config.Lock.Update(leaderElectionRecord); err != nil {

--- a/tools/leaderelection/leaderelection.go
+++ b/tools/leaderelection/leaderelection.go
@@ -300,7 +300,7 @@ func (le *LeaderElector) release() bool {
 		return true
 	}
 	leaderElectionRecord := rl.LeaderElectionRecord{
-		LeaseDurationSeconds: int(le.config.LeaseDuration.Seconds()),
+		LeaseDurationSeconds: le.observedRecord.LeaseDurationSeconds,
 		LeaderTransitions: le.observedRecord.LeaderTransitions,
 	}
 	if err := le.config.Lock.Update(leaderElectionRecord); err != nil {


### PR DESCRIPTION
Fix for the following error

```leaderelection.go:300] Failed to release lock: Lease.coordination.k8s.io "some-lock" is invalid: spec.leaseDurationSeconds: Invalid value: 0: must be greater than 0```