### PR TITLE
Fix CONTRIBUTING.md to avoid conflicts while publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,6 @@
 # Contributing guidelines
 
-Do not open pull requests directly against this repository. They will be ignored. Instead, please open pull requests against [kubernetes/kubernetes](https://git.k8s.io/kubernetes/). 
-The exception is changes to the `README.md` itself. 
-Please follow the same [contributing guide](https://git.k8s.io/kubernetes/CONTRIBUTING.md) you would follow for any other pull request made to kubernetes/kubernetes.
+Do not open pull requests directly against this repository, they will be ignored. Instead, please open pull requests against [kubernetes/kubernetes](https://git.k8s.io/kubernetes/).  Please follow the same [contributing guide](https://git.k8s.io/kubernetes/CONTRIBUTING.md) you would follow for any other pull request made to kubernetes/kubernetes.
 
 This repository is published from [kubernetes/kubernetes/staging/src/k8s.io/client-go](https://git.k8s.io/kubernetes/staging/src/k8s.io/client-go) by the [kubernetes publishing-bot](https://git.k8s.io/publishing-bot).
 


### PR DESCRIPTION
Comparing the history of:

- the CONTRIBUTING.md file in k/client-go: https://github.com/kubernetes/client-go/commits/master/CONTRIBUTING.md and
- the CONTRIBUTING.md file in staging: https://github.com/kubernetes/kubernetes/commits/master/staging/src/k8s.io/client-go/CONTRIBUTING.md

We see that the one in staging diverged from the one being published,
_even though commits were being published the bot_. The divergence occurs
because the one in staging lacks the following commit:
https://github.com/kubernetes/client-go/commit/12a6e5ed0a50aa9cef1766eab1d7547e90ea8a8a#diff-6a3371457528722a734f3c51d9238c13.

This occurred because we merged a PR to k/client-go directly
(https://github.com/kubernetes/client-go/pull/421) long ago, which instead should have been routed through
staging.

The commits that were created through staging _after_ the above PR was
merged were still being published by the bot because they didn't
introduce conflicts (and we never found out about it since no conflicts
were detected).

Recently, a PR (https://github.com/kubernetes/kubernetes/pull/85464)
introduced changes that touched the line changed by the
offending/divergent commit. When these changes were cherry-picked
to the master branch to be published, the bot complained with conflicts.

This PR brings the CONTRIBUTING.md file to a state
(https://github.com/kubernetes/kubernetes/blob/36065c6dd717c14e0a90131041e20345a7e5e324/staging/src/k8s.io/client-go/CONTRIBUTING.md)
before the new PR (https://github.com/kubernetes/kubernetes/pull/85464) was merged,
so that cherry-picking the changes in this PR to the master branch
won't introduce conflicts anymore.
