### PR TITLE
Update install instructions to match the minimum version for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ you care about backwards compatibility.
 Use go1.11+ and fetch the desired version using the `go get` command. For example:
 
 ```
-go get k8s.io/client-go@v0.17.0
+go get k8s.io/client-go@v0.18.0
 ```
 
 See [INSTALL.md](/INSTALL.md) for detailed instructions.


### PR DESCRIPTION
The suggested version in the README does not match the API currently used on the examples.

Compiling `client-go/examples/out-of-cluster-client-configuration/main.go` fails if one follows the instructions on the `README.md`. The minimum compatible version is `k8s.io/client-go@v0.18.0`.

### Steps to reproduce

```
mkdir some-dir && cd some-dir
go mod init some/package
go get k8s.io/client-go@v0.17.0
curl -sSLo main.go https://raw.githubusercontent.com/kubernetes/client-go/60a0346672170c8e9f65795fb33e41527980c583/examples/out-of-cluster-client-configuration/main.go
go build
```

Error

```
./main.go:64:48: too many arguments in call to clientset.CoreV1().Pods("").List
	have (context.Context, "k8s.io/apimachinery/pkg/apis/meta/v1".ListOptions)
	want ("k8s.io/apimachinery/pkg/apis/meta/v1".ListOptions)
./main.go:75:50: too many arguments in call to clientset.CoreV1().Pods(namespace).Get
	have (context.Context, string, "k8s.io/apimachinery/pkg/apis/meta/v1".GetOptions)
	want (string, "k8s.io/apimachinery/pkg/apis/meta/v1".GetOptions)
```

Fix

```
go get k8s.io/client-go@v0.18.0
go build
```