### PR TITLE
README: add 1.19 in compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ We will backport bugfixes--but not new features--into older versions of
 
 #### Compatibility matrix
 
-|                               | Kubernetes 1.15 | Kubernetes 1.16 | Kubernetes 1.17 | Kubernetes 1.18 |
-|-------------------------------|-----------------|-----------------|-----------------|-----------------|
-| `kubernetes-1.15.0`           | ✓               | +-              | +-              | +-              |
-| `kubernetes-1.16.0`           | +-              | ✓               | +-              | +-              |
-| `kubernetes-1.17.0`/`v0.17.0` | +-              | +-              | ✓               | +-              |
-| `kubernetes-1.18.0`/`v0.18.0` | +-              | +-              | +-              | ✓               |
-| `HEAD`                        | +-              | +-              | +-              | +-              |
+|                               | Kubernetes 1.15 | Kubernetes 1.16 | Kubernetes 1.17 | Kubernetes 1.18 | Kubernetes 1.19 |
+|-------------------------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+| `kubernetes-1.15.0`           | ✓               | +-              | +-              | +-              | +-              |
+| `kubernetes-1.16.0`           | +-              | ✓               | +-              | +-              | +-              |
+| `kubernetes-1.17.0`/`v0.17.0` | +-              | +-              | ✓               | +-              | +-              |
+| `kubernetes-1.18.0`/`v0.18.0` | +-              | +-              | +-              | ✓               | +-              |
+| `kubernetes-1.19.0`/`v0.19.0` | +-              | +-              | +-              | +-              | ✓               |
+| `HEAD`                        | +-              | +-              | +-              | +-              | +-              |
 
 Key:
 
@@ -121,10 +122,11 @@ between client-go versions.
 | `release-9.0`  | Kubernetes main repo, 1.12 branch    | =-                            |
 | `release-10.0` | Kubernetes main repo, 1.13 branch    | =-                            |
 | `release-11.0` | Kubernetes main repo, 1.14 branch    | =-                            |
-| `release-12.0` | Kubernetes main repo, 1.15 branch    | ✓                             |
+| `release-12.0` | Kubernetes main repo, 1.15 branch    | =-                            |
 | `release-13.0` | Kubernetes main repo, 1.16 branch    | ✓                             |
 | `release-14.0` | Kubernetes main repo, 1.17 branch    | ✓                             |
 | `release-1.18` | Kubernetes main repo, 1.18 branch    | ✓                             |
+| `release-1.19` | Kubernetes main repo, 1.19 branch    | ✓                             |
 | client-go HEAD | Kubernetes main repo, master branch  | ✓                             |
 
 Key:
@@ -174,7 +176,7 @@ you care about backwards compatibility.
 Use go1.11+ and fetch the desired version using the `go get` command. For example:
 
 ```
-go get k8s.io/client-go@v0.17.0
+go get k8s.io/client-go@v0.19.0
 ```
 
 See [INSTALL.md](/INSTALL.md) for detailed instructions.


### PR DESCRIPTION
1.19 will be released tomorrow, this PR adds 1.19 to the compatibility matrix in the README. This PR shouldn't be merged until 1.19 is released.

Creating the PR earlier this time round to ensure we don't forget it like last time :grimacing: (https://github.com/kubernetes/client-go/pull/821).
/hold

/assign @sttts 