### PR TITLE
README: add 1.20 in compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,15 @@ We will backport bugfixes--but not new features--into older versions of
 
 #### Compatibility matrix
 
-|                               | Kubernetes 1.15 | Kubernetes 1.16 | Kubernetes 1.17 | Kubernetes 1.18 | Kubernetes 1.19 |
-|-------------------------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-| `kubernetes-1.15.0`           | ✓               | +-              | +-              | +-              | +-              |
-| `kubernetes-1.16.0`           | +-              | ✓               | +-              | +-              | +-              |
-| `kubernetes-1.17.0`/`v0.17.0` | +-              | +-              | ✓               | +-              | +-              |
-| `kubernetes-1.18.0`/`v0.18.0` | +-              | +-              | +-              | ✓               | +-              |
-| `kubernetes-1.19.0`/`v0.19.0` | +-              | +-              | +-              | +-              | ✓               |
-| `HEAD`                        | +-              | +-              | +-              | +-              | +-              |
+|                               | Kubernetes 1.15 | Kubernetes 1.16 | Kubernetes 1.17 | Kubernetes 1.18 | Kubernetes 1.19 | Kubernetes 1.20 |
+|-------------------------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+| `kubernetes-1.15.0`           | ✓               | +-              | +-              | +-              | +-              | +-              |
+| `kubernetes-1.16.0`           | +-              | ✓               | +-              | +-              | +-              | +-              |
+| `kubernetes-1.17.0`/`v0.17.0` | +-              | +-              | ✓               | +-              | +-              | +-              |
+| `kubernetes-1.18.0`/`v0.18.0` | +-              | +-              | +-              | ✓               | +-              | +-              |
+| `kubernetes-1.19.0`/`v0.19.0` | +-              | +-              | +-              | +-              | ✓               | +-              |
+| `kubernetes-1.20.0`/`v0.20.0` | +-              | +-              | +-              | +-              | +-              | ✓               |
+| `HEAD`                        | +-              | +-              | +-              | +-              | +-              | +-              |
 
 Key:
 
@@ -123,10 +124,11 @@ between client-go versions.
 | `release-10.0` | Kubernetes main repo, 1.13 branch    | =-                            |
 | `release-11.0` | Kubernetes main repo, 1.14 branch    | =-                            |
 | `release-12.0` | Kubernetes main repo, 1.15 branch    | =-                            |
-| `release-13.0` | Kubernetes main repo, 1.16 branch    | ✓                             |
+| `release-13.0` | Kubernetes main repo, 1.16 branch    | =-                            |
 | `release-14.0` | Kubernetes main repo, 1.17 branch    | ✓                             |
 | `release-1.18` | Kubernetes main repo, 1.18 branch    | ✓                             |
 | `release-1.19` | Kubernetes main repo, 1.19 branch    | ✓                             |
+| `release-1.20` | Kubernetes main repo, 1.20 branch    | ✓                             |
 | client-go HEAD | Kubernetes main repo, master branch  | ✓                             |
 
 Key:
@@ -176,7 +178,7 @@ you care about backwards compatibility.
 Use go1.11+ and fetch the desired version using the `go get` command. For example:
 
 ```
-go get k8s.io/client-go@v0.19.0
+go get k8s.io/client-go@v0.20.0
 ```
 
 See [INSTALL.md](/INSTALL.md) for detailed instructions.


### PR DESCRIPTION
Similar to #851, update the compatibility matrix for Kubernetes v1.20.

/cc @lilic @nikhita @sttts 