### PR TITLE
Retract pre-module versions and v1.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,46 @@
+module k8s.io/client-go
+
+go 1.16
+
+retract (
+	// pre-module versions are obsolete
+	v12.0.0+incompatible
+	// pre-module versions are obsolete
+	v11.0.0+incompatible
+	// pre-module versions are obsolete
+	v10.0.0+incompatible
+	// pre-module versions are obsolete
+	v9.0.0+incompatible
+	// pre-module versions are obsolete
+	v9.0.0-invalid+incompatible
+	// pre-module versions are obsolete
+	v8.0.0+incompatible
+	// pre-module versions are obsolete
+	v7.0.0+incompatible
+	// pre-module versions are obsolete
+	v6.0.0+incompatible
+	// pre-module versions are obsolete
+	v5.0.1+incompatible
+	// pre-module versions are obsolete
+	v5.0.0+incompatible
+	// pre-module versions are obsolete
+	v4.0.0+incompatible
+	// pre-module versions are obsolete
+	v4.0.0-beta.0+incompatible
+	// pre-module versions are obsolete
+	v3.0.0+incompatible
+	// pre-module versions are obsolete
+	v3.0.0-beta.0+incompatible
+	// pre-module versions are obsolete
+	v2.0.0+incompatible
+	// pre-module versions are obsolete
+	v2.0.0-alpha.1+incompatible
+	// pre-module versions are obsolete
+	v1.5.2
+	// pre-module versions are obsolete
+	v1.5.1
+	// pre-module versions are obsolete
+	v1.5.0
+	// pre-module versions are obsolete
+	v1.4.0
+)


### PR DESCRIPTION
Proposed as part of https://github.com/kubernetes/kubernetes/issues/98267

Based on v1.5.1 content, intended to merge to the release-1.5 branch and have a v1.5.2 tag cut