### PR TITLE
Fix Deferring unsafe method "Close" on type "*os.File" Gosec G307 warning

### DIFF
--- a/discovery/cached/disk/cached_discovery.go
+++ b/discovery/cached/disk/cached_discovery.go
@@ -147,7 +147,12 @@ func (d *CachedDiscoveryClient) getCachedFile(filename string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+
+	defer func() {
+		if err := file.Close(); err != nil {
+			klog.Errorf("Failed to close file: %v", err)
+		}
+	}()
 
 	fileInfo, err := file.Stat()
 	if err != nil {


### PR DESCRIPTION
…ning

Sorry, we do not accept changes directly against this repository, unless the
change is to the `README.md` itself. Please see
`CONTRIBUTING.md` for information on where and how to contribute instead.
