### PR TITLE
Fix Deferring unsafe method "Close" on type "*os.File" Gosec G307 warning

### DIFF
--- a/util/certificate/certificate_store.go
+++ b/util/certificate/certificate_store.go
@@ -197,7 +197,12 @@ func (s *fileStore) Update(certData, keyData []byte) (*tls.Certificate, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not open %q: %v", certPath, err)
 	}
-	defer f.Close()
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			klog.Errorf("Failed to close file: %v", err)
+		}
+	}()
 
 	// First cert is leaf, remainder are intermediates
 	certs, err := certutil.ParseCertsPEM(certData)


### PR DESCRIPTION
…ning

Sorry, we do not accept changes directly against this repository, unless the
change is to the `README.md` itself. Please see
`CONTRIBUTING.md` for information on where and how to contribute instead.
