### PR TITLE
Update in-cluster-client-configuration example

### DIFF
--- a/examples/in-cluster-client-configuration/Dockerfile
+++ b/examples/in-cluster-client-configuration/Dockerfile
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian
-COPY ./app /app
-ENTRYPOINT /app
+FROM golang:alpine as builder
+RUN mkdir -p /app
+COPY . /app
+WORKDIR /app
+RUN go mod init cluster
+RUN go mod tidy && go mod vendor
+RUN go build -mod=vendor -o app
+
+FROM alpine
+COPY --from=builder /app/app /usr/bin/app
+ENTRYPOINT /usr/bin/app

--- a/examples/in-cluster-client-configuration/README.md
+++ b/examples/in-cluster-client-configuration/README.md
@@ -9,13 +9,11 @@ client-go uses the [Service Account token][sa] mounted inside the Pod at the
 
 ## Running this example
 
-First compile the application for Linux:
+First:
 
     cd in-cluster-client-configuration
-    GOOS=linux go build -o ./app .
 
-Then package it to a docker image using the provided Dockerfile to run it on
-Kubernetes.
+Then using the provided Dockerfile to run it on Kubernetes.
 
 If you are running a [Minikube][mk] cluster, you can build this image directly
 on the Docker engine of the Minikube node without pushing it to a registry. To
@@ -25,7 +23,8 @@ build the image on Minikube:
     docker build -t in-cluster .
 
 If you are not using Minikube, you should build this image and push it to a registry
-that your Kubernetes cluster can pull from.
+that your Kubernetes cluster can pull from. In China, you may need to set GOPROXY
+in the Dockerfile.
 
 If you have RBAC enabled on your cluster, use the following
 snippet to create role binding which will grant the default service account view
@@ -37,7 +36,7 @@ kubectl create clusterrolebinding default-view --clusterrole=view --serviceaccou
 
 Then, run the image in a Pod with a single instance Deployment:
 
-    kubectl run --rm -i demo --image=in-cluster
+    kubectl run --rm -i demo --image=in-cluster --image-pull-policy=IfNotPresent
 
     There are 4 pods in the cluster
     There are 4 pods in the cluster


### PR DESCRIPTION
Update Dockerfile and README.md in example/in-cluster-client-configuration.
1. Update Dockerfile, no need to cross-compile locally；
2. Update README.md, add --image-pull-policy=IfNotPresent to use the local image.