### PR TITLE
Added OWNERS file

### DIFF
--- a/scale/OWNERS
+++ b/scale/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+-
+-
+reviewers:
+-
+-


### PR DESCRIPTION
Currently the [link](https://github.com/kubernetes/client-go/blob/master/scale/OWNERS) under [this](https://github.com/kubernetes/community/blob/master/sig-autoscaling/README.md#scale-client) section of the sig-autoscaling readme file is broken. 

As part of this fix OWNERS file has been introduced; however the file currently doesn't really have any details of the approver and reviewer as I am unaware of those details. If these details could be shared, then I can add them to this file. Right now the fix introduces a OWNERS template file.