### PR TITLE
Add link title to Go Docs widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ See [INSTALL.md](/INSTALL.md) for detailed installation instructions and trouble
 
 [![GoDocWidget]][GoDocReference]
 
-[GoDocWidget]: https://godoc.org/k8s.io/client-go?status.svg
-[GoDocReference]:https://godoc.org/k8s.io/client-go 
+[GoDocWidget]: https://godoc.org/k8s.io/client-go?status.svg "Client Go Docs"
+[GoDocReference]: https://godoc.org/k8s.io/client-go
 
 ## Table of Contents
 


### PR DESCRIPTION
This improves accessibility for people using screen readers.

Please feel free to suggest another phrase to use; I'm not married to this particular one!