### PR TITLE
Suppress duplicates between FIFO and priority queue of waiting items

### DIFF
--- a/util/workqueue/delaying_queue_test.go
+++ b/util/workqueue/delaying_queue_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 	testingclock "k8s.io/utils/clock/testing"
 )
@@ -123,6 +125,15 @@ func TestDeduping(t *testing.T) {
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
 	}
+
+	// test again, but this time item is being processed in FIFO
+	q.Add(first)
+	i, _ := q.Get()
+	assert.Equal(t, first, i)
+	q.AddAfter(first, 5*time.Millisecond)
+	found, _ := q.Find(first)
+	assert.True(t, found)
+	q.Done(first)
 }
 
 func TestAddTwoFireEarly(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

Fixes [#110642](https://github.com/kubernetes/kubernetes/issues/110642)

**Which issue(s) this PR fixes:**

[delaying queue](https://github.com/kubernetes/client-go/blob/master/util/workqueue/delaying_queue.go) suppresses duplicates within the FIFO, and suppresses duplicates within the priority queue of waiting items, but does not suppress duplicates between them.

These changes suppress duplicates within each of those two queues so that an item already being processed in the FIFO is not added again to the priority queue; which eliminates double processing a single item. The change adds a new function `Find` on the FIFO queue to find if an item is already present in the queue or being processed. The priority queue checks the duplicates by using Find before adding an item to the priority queue.

**Special notes for your reviewer:**

NONE

**Does this PR introduce a user-facing change?**

NONE