### PR TITLE
Fix comment

### DIFF
--- a/tools/leaderelection/resourcelock/interface.go
+++ b/tools/leaderelection/resourcelock/interface.go
@@ -68,7 +68,7 @@ const (
 	//           name: '*'
 	//           namespace: kube-system
 	EndpointsLeasesResourceLock = "endpointsleases"
-	// When using EndpointsLeasesResourceLock, you need to ensure that
+	// When using ConfigMapsLeasesResourceLock, you need to ensure that
 	// API Priority & Fairness is configured with non-default flow-schema
 	// that will catch the necessary operations on leader-election related
 	// configmap objects.


### PR DESCRIPTION
Comment which is reffering to `ConfigMapsLeasesResourceLock` said
`EndpointsLeasesResourceLock` instead which was confusing

Sorry, we do not accept changes directly against this repository, unless the
change is to the `README.md` itself. Please see
`CONTRIBUTING.md` for information on where and how to contribute instead.
