### PR TITLE
#1238 | Fix flag redefined: kubeconfig in out-of-cluster-client-confi…

### DIFF
--- a/examples/out-of-cluster-client-configuration/main.go
+++ b/examples/out-of-cluster-client-configuration/main.go
@@ -40,16 +40,22 @@ import (
 )
 
 func main() {
-	var kubeconfig *string
-	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	var kubeconfig string
+
+	if flag.Lookup("kubeconfig") == nil {
+
+		if home := homedir.HomeDir(); home != "" {
+			flag.StringVar(&kubeconfig, "kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+		} else {
+			flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+		}
 	}
+	kubeconfig = flag.Lookup("kubeconfig").Value.(flag.Getter).Get().(string)
+
 	flag.Parse()
 
 	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
…guration

- Inspired by this stackoverflow answer https://stackoverflow.com/a/49195212/9431161 about that every flag may only be registered once.

Sorry, we do not accept changes directly against this repository, unless the
change is to the `README.md` itself. Please see
`CONTRIBUTING.md` for information on where and how to contribute instead.
