### PR TITLE
Add support for oidc auth provider in kubeconfig

### DIFF
--- a/plugin/pkg/client/auth/oidc/oidc.go
+++ b/plugin/pkg/client/auth/oidc/oidc.go
@@ -30,6 +30,7 @@ import (
 
 	"golang.org/x/oauth2"
 	"k8s.io/apimachinery/pkg/util/net"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 )


### PR DESCRIPTION
the plugin does not work for our kubeconfig with relies on an oidc as the auth provider:

```
> helm mapkubeapis --mapfile $HOME/.kube/fix-cert-manager-api.yaml galvani --dry-run
2023/04/17 12:09:56 NOTE: This is in dry-run mode, the following actions will not be executed.
2023/04/17 12:09:56 Run without --dry-run to take the actions described below:
2023/04/17 12:09:56
2023/04/17 12:09:56 Release 'galvani' will be checked for deprecated or removed Kubernetes APIs and will be updated if necessary to supported API versions.
2023/04/17 12:09:56 Get release 'galvani' latest version.
Error: failed to get release 'galvani' latest version: query: failed to query with labels: no Auth Provider found for name "oidc"
Error: plugin "mapkubeapis" exited with error
```

Sorry, we do not accept changes directly against this repository, unless the
change is to the `README.md` itself. Please see
`CONTRIBUTING.md` for information on where and how to contribute instead.
