### PR TITLE
fix: add timestamp to fake log line to match actual API

### DIFF
--- a/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
+++ b/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
@@ -68,7 +68,7 @@ func (c *FakePods) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Requ
 		Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader("fake logs")),
+				Body:       io.NopCloser(strings.NewReader("2006-01-02T15:04:05.999999999Z07:00 fake logs")),
 			}
 			return resp, nil
 		}),


### PR DESCRIPTION
I'm working on tests for Argo CD's log fetcher. Our log parsing logic assumes lines start with timestamps. That works for actual API responses, but not the fake log response.

I can fix the test by adding logic to skip timestamp parsing. But it would be nice to have the change upstream as well.

Sorry, we do not accept changes directly against this repository, unless the
change is to the `README.md` itself. Please see
`CONTRIBUTING.md` for information on where and how to contribute instead.
