### PR TITLE
Fix the broken link in README.md

### DIFF
--- a/examples/in-cluster-client-configuration/README.md
+++ b/examples/in-cluster-client-configuration/README.md
@@ -54,5 +54,5 @@ the `kubectl run` command and then run:
 
     kubectl delete deployment demo
 
-[sa]: https://kubernetes.io/docs/admin/authentication/#service-account-tokens
+[sa]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens
 [mk]: https://kubernetes.io/docs/getting-started-guides/minikube/


### PR DESCRIPTION
Fixed the broken link: Service Account Tokens

Replaced the link `https://kubernetes.io/docs/admin/authentication/#service-account-tokens` with `https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens`
