### PR TITLE
chore(docs): refresh compatibility matrix to include versions 1.29 and 1.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ We will backport bugfixes--but not new features--into older versions of
 
 #### Compatibility matrix
 
-|                               | Kubernetes 1.23 | Kubernetes 1.24 | Kubernetes 1.25 | Kubernetes 1.26 | Kubernetes 1.27 | Kubernetes 1.28 |
+|                               | Kubernetes 1.25 | Kubernetes 1.26 | Kubernetes 1.27 | Kubernetes 1.28 | Kubernetes 1.29 | Kubernetes 1.30 |
 | ----------------------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- |
-| `kubernetes-1.23.0`/`v0.23.0` | ✓               | +-              | +-              | +-              | +-              | +-              |
-| `kubernetes-1.24.0`/`v0.24.0` | +-              | ✓               | +-              | +-              | +-              | +-              |
-| `kubernetes-1.25.0`/`v0.25.0` | +-              | +-              | ✓               | +-              | +-              | +-              |
-| `kubernetes-1.26.0`/`v0.26.0` | +-              | +-              | +-              | ✓               | +-              | +-              |
-| `kubernetes-1.27.0`/`v0.27.0` | +-              | +-              | +-              | +-              | ✓               | +-              |
-| `kubernetes-1.28.0`/`v0.28.0` | +-              | +-              | +-              | +-              | +-              | ✓               |
+| `kubernetes-1.25.0`/`v0.25.0` | ✓               | +-              | +-              | +-              | +-              | +-              |
+| `kubernetes-1.26.0`/`v0.26.0` | +-              | ✓               | +-              | +-              | +-              | +-              |
+| `kubernetes-1.27.0`/`v0.27.0` | +-              | +-              | ✓               | +-              | +-              | +-              |
+| `kubernetes-1.28.0`/`v0.28.0` | +-              | +-              | +-              | ✓               | +-              | +-              |
+| `kubernetes-1.29.0`/`v0.29.0` | +-              | +-              | +-              | +-              | ✓               | +-              |
+| `kubernetes-1.30.0`/`v0.30.0` | +-              | +-              | +-              | +-              | +-              | ✓               |
 | `HEAD`                        | +-              | +-              | +-              | +-              | +-              | +-              |
 
 Key:
@@ -114,6 +114,8 @@ between client-go versions.
 | `release-1.26` | Kubernetes main repo, 1.26 branch   | ✓                  |
 | `release-1.27` | Kubernetes main repo, 1.27 branch   | ✓                  |
 | `release-1.28` | Kubernetes main repo, 1.28 branch   | ✓                  |
+| `release-1.29` | Kubernetes main repo, 1.29 branch   | ✓                  |
+| `release-1.30` | Kubernetes main repo, 1.30 branch   | ✓                  |
 | client-go HEAD | Kubernetes main repo, master branch | ✓                  |
 
 Key:


### PR DESCRIPTION
Bring the compatibility matrix up-to-date to include version 1.29 and 1.30 of Kubernetes.

Fixes #1353 
